### PR TITLE
EI-1374 Downgrade min grpcio version

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -21,7 +21,9 @@ package_dir =
     =src
 install_requires =
     googleapis-common-protos>=1.56.3
-    grpcio>=1.44.0
+    # pinned grpcio version to 1.44.0 to fix working on raspberry Pi 
+    # c.f. https://stackoverflow.com/questions/71054519/glibc-2-33-not-found-in-raspberry-pi-python/72485013#72485013
+    grpcio==1.44.0
 
 [options.extras_require]
 dev =

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = iotics-grpc-client
-version = 0.0.1
+version = 0.0.2
 description = Iotics gRPC client library
 long_description = file: README.md
 long_description_content_type = text/markdown
@@ -21,7 +21,7 @@ package_dir =
     =src
 install_requires =
     googleapis-common-protos>=1.56.3
-    grpcio>=1.47.0
+    grpcio>=1.44.0
 
 [options.extras_require]
 dev =


### PR DESCRIPTION
I tested by running the examples against gaia (as e2e is not working) with `grpcio==1.44.0`  and all the examples ran fine