### PR TITLE
ei-3055: list twins

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,11 +5,11 @@ VENV_PATH ?= ./env
 UNAME_S := $(shell uname -s)
 UNAME_M := $(shell uname -m)
 
-PYTHON_CMD = python3
-PYTHON3_OK := $(shell python3 --version 2>&1)
-ifeq ('$(PYTHON3_OK)','')
-    $(error package 'python3' not found)
-	PYTHON_CMD = python
+PYTHON_CMD = python
+PYTHON_OK := $(shell python --version 2>&1)
+ifeq ('$(PYTHON_OK)','')
+    $(error package 'python' not found)
+	PYTHON_CMD = python3
 endif
 
 ifeq ($(OS),Windows_NT)

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 SHELL := /bin/bash
 BUF_VERSION ?= 1.32.1
-PROTOC_VERSION ?= 26.1
+PROTOC_VERSION ?= 27.1
 VENV_PATH ?= ./env
 UNAME_S := $(shell uname -s)
 UNAME_M := $(shell uname -m)
@@ -45,7 +45,7 @@ buf-lint: deps-buf
 buf-list:
 	$(BUF) ls-files
 
-generate: deps-proto deps-py deps-go buf-list buf-lint
+generate: deps-proto deps-py deps-go-update buf-list buf-lint
 	source "$(VENV_PATH)"/bin/activate \
 	&& $(BUF) generate $(GEN_ARGS)
 

--- a/Makefile
+++ b/Makefile
@@ -5,6 +5,13 @@ VENV_PATH ?= ./env
 UNAME_S := $(shell uname -s)
 UNAME_M := $(shell uname -m)
 
+PYTHON_CMD = python3
+PYTHON3_OK := $(shell python3 --version 2>&1)
+ifeq ('$(PYTHON3_OK)','')
+    $(error package 'python3' not found)
+	PYTHON_CMD = python
+endif
+
 ifeq ($(OS),Windows_NT)
   VENV_PATH_DIR=Scripts
 else
@@ -83,10 +90,10 @@ deps-buf-update buf.lock:
 	$(BUF) dep update
 
 deps-py:
-	python -m venv "$(VENV_PATH)"
+	${PYTHON_CMD} -m venv "$(VENV_PATH)"
 	source "$(VENV_PATH)"/"$(VENV_PATH_DIR)"/activate \
-	&& python -m pip install -U pip setuptools \
-	&& python -m pip install -e '.[dev]'
+	&& ${PYTHON_CMD} -m pip install -U pip setuptools \
+	&& ${PYTHON_CMD} -m pip install -e '.[dev]'
 deps-py-update: clean deps-py
 
 
@@ -96,13 +103,13 @@ deps-py-update: clean deps-py
 
 verify-import: deps-py
 	source "$(VENV_PATH)"/"$(VENV_PATH_DIR)"/activate \
-	&& python -c 'from iotics.lib.grpc import IoticsApi'
+	&& ${PYTHON_CMD} -c 'from iotics.lib.grpc import IoticsApi'
 
 run-examples: deps-py
 	source "$(VENV_PATH)"/"$(VENV_PATH_DIR)"/activate \
-	&& python examples/search_twin_models.py \
-	&& python examples/search_location.py \
-	&& python examples/sparql.py \
-	&& python examples/create_edit_twins_feeds.py \
-	&& python examples/follow_feed.py \
-	&& python examples/inputs.py
+	&& ${PYTHON_CMD} examples/search_twin_models.py \
+	&& ${PYTHON_CMD} examples/search_location.py \
+	&& ${PYTHON_CMD} examples/sparql.py \
+	&& ${PYTHON_CMD} examples/create_edit_twins_feeds.py \
+	&& ${PYTHON_CMD} examples/follow_feed.py \
+	&& ${PYTHON_CMD} examples/inputs.py

--- a/Makefile
+++ b/Makefile
@@ -5,13 +5,6 @@ VENV_PATH ?= ./env
 UNAME_S := $(shell uname -s)
 UNAME_M := $(shell uname -m)
 
-PYTHON_CMD = python
-PYTHON_OK := $(shell python --version 2>&1)
-ifeq ('$(PYTHON_OK)','')
-    $(error package 'python' not found)
-	PYTHON_CMD = python3
-endif
-
 ifeq ($(OS),Windows_NT)
   VENV_PATH_DIR=Scripts
 else
@@ -90,10 +83,10 @@ deps-buf-update buf.lock:
 	$(BUF) dep update
 
 deps-py:
-	${PYTHON_CMD} -m venv "$(VENV_PATH)"
+	python3 -m venv "$(VENV_PATH)"
 	source "$(VENV_PATH)"/"$(VENV_PATH_DIR)"/activate \
-	&& ${PYTHON_CMD} -m pip install -U pip setuptools \
-	&& ${PYTHON_CMD} -m pip install -e '.[dev]'
+	&& python -m pip install -U pip setuptools \
+	&& python -m pip install -e '.[dev]'
 deps-py-update: clean deps-py
 
 
@@ -103,13 +96,14 @@ deps-py-update: clean deps-py
 
 verify-import: deps-py
 	source "$(VENV_PATH)"/"$(VENV_PATH_DIR)"/activate \
-	&& ${PYTHON_CMD} -c 'from iotics.lib.grpc import IoticsApi'
+	&& python -c 'from iotics.lib.grpc import IoticsApi'
 
 run-examples: deps-py
 	source "$(VENV_PATH)"/"$(VENV_PATH_DIR)"/activate \
-	&& ${PYTHON_CMD} examples/search_twin_models.py \
-	&& ${PYTHON_CMD} examples/search_location.py \
-	&& ${PYTHON_CMD} examples/sparql.py \
-	&& ${PYTHON_CMD} examples/create_edit_twins_feeds.py \
-	&& ${PYTHON_CMD} examples/follow_feed.py \
-	&& ${PYTHON_CMD} examples/inputs.py
+	&& python examples/search_twin_models.py \
+	&& python examples/search_location.py \
+	&& python examples/sparql.py \
+	&& python examples/create_edit_twins_feeds.py \
+	&& python examples/follow_feed.py \
+	&& python examples/inputs.py \
+	&& python examples/list_local_twins.py

--- a/examples/list_local_twins.py
+++ b/examples/list_local_twins.py
@@ -1,0 +1,59 @@
+import os
+import uuid
+
+import dotenv
+import grpc._channel
+
+from identity_auth import IdentityAuth, IdentityAuthError
+from iotics.lib.grpc.iotics_api import IoticsApi
+from iotics.lib.grpc.helpers import PER_PAGE_LIMIT
+
+
+def main():
+    dotenv.load_dotenv()
+    try:
+        auth = IdentityAuth(
+            os.environ['SPACE'],
+            os.getenv('DID_RESOLVER_URL'),
+            os.environ['USER_DID'],
+            os.environ['AGENT_DID'],
+            os.environ['AGENT_KEY_NAME'],
+            os.environ['AGENT_NAME'],
+            os.environ['AGENT_SECRET'],
+            os.getenv('TOKEN_TTL')
+        )
+    except IdentityAuthError as error:
+        print(error)
+        return
+
+    api = IoticsApi(auth)
+    try:
+        list_local_twins(api)
+    except grpc.RpcError as error:
+        error: grpc._channel._MultiThreadedRendezvous
+        print('Error from gRPC:', error.details())
+
+
+def list_local_twins(api):
+    client_app_id = uuid.uuid4().hex
+
+    host_count = 1
+    local_host_id = api.get_local_host_id()
+
+    #limit > 100 throws an grpc param error
+    twins_total_count=PER_PAGE_LIMIT
+    all_twin_count = 0
+    page_num=0
+    while twins_total_count==PER_PAGE_LIMIT :
+        twin_list = api.list_twins(page=page_num)
+        twins_total_count = len(twin_list.payload.twins)
+        all_twin_count+=twins_total_count
+        print(f'Got replies from page #{page_num} and found {twins_total_count} twins on this page.')
+        page_num+=1
+
+    print(f'found {all_twin_count} twins in total.')
+
+    #print (twin_list)
+
+if __name__ == '__main__':
+    main()

--- a/examples/list_local_twins.py
+++ b/examples/list_local_twins.py
@@ -35,10 +35,6 @@ def main():
 
 
 def list_local_twins(api):
-    client_app_id = uuid.uuid4().hex
-
-    host_count = 1
-    local_host_id = api.get_local_host_id()
 
     #limit > 100 throws an grpc param error
     twins_total_count=PER_PAGE_LIMIT
@@ -52,8 +48,6 @@ def list_local_twins(api):
         page_num+=1
 
     print(f'found {all_twin_count} twins in total.')
-
-    #print (twin_list)
 
 if __name__ == '__main__':
     main()

--- a/src/iotics/lib/grpc/helpers.py
+++ b/src/iotics/lib/grpc/helpers.py
@@ -47,6 +47,7 @@ KEEP_ALIVE_CHANNEL_OPTIONS = [
     ("grpc.http2.max_pings_without_data", 0),
 ]
 
+PER_PAGE_LIMIT = 100
 
 def get_channel(
     auth: AuthInterface, channel_options: [tuple, ...] = None

--- a/src/iotics/lib/grpc/search.py
+++ b/src/iotics/lib/grpc/search.py
@@ -21,11 +21,8 @@ from google.protobuf.wrappers_pb2 import StringValue
 from iotics.api import common_pb2
 from iotics.api import search_pb2
 from iotics.api import search_pb2_grpc
-from iotics.lib.grpc.helpers import create_headers
+from iotics.lib.grpc.helpers import create_headers, PER_PAGE_LIMIT
 from iotics.lib.grpc.base import ApiBase
-
-PER_PAGE_LIMIT = 100
-
 
 class SearchApi(ApiBase):
     stub_class = search_pb2_grpc.SearchAPIStub

--- a/src/iotics/lib/grpc/twins.py
+++ b/src/iotics/lib/grpc/twins.py
@@ -20,7 +20,7 @@ from iotics.api import input_pb2
 from iotics.api import twin_pb2
 from iotics.api import twin_pb2_grpc
 from .base import ApiBase
-from .helpers import create_headers,PER_PAGE_LIMIT
+from .helpers import create_headers, PER_PAGE_LIMIT
 
 
 class TwinApi(ApiBase):
@@ -90,7 +90,7 @@ class TwinApi(ApiBase):
         return self.stub.DeleteTwin(req)
 
     def list_twins(self, 
-                   page:int =0,
+                   page:int = 0,
                    headers: typing.Optional[common_pb2.Headers] = None
     ) -> twin_pb2.ListAllTwinsResponse:
         """Lists all local twins visible to the user making the request

--- a/src/iotics/lib/grpc/twins.py
+++ b/src/iotics/lib/grpc/twins.py
@@ -20,7 +20,7 @@ from iotics.api import input_pb2
 from iotics.api import twin_pb2
 from iotics.api import twin_pb2_grpc
 from .base import ApiBase
-from .helpers import create_headers
+from .helpers import create_headers,PER_PAGE_LIMIT
 
 
 class TwinApi(ApiBase):
@@ -89,15 +89,25 @@ class TwinApi(ApiBase):
             args=twin_pb2.DeleteTwinRequest.Arguments(twinId=common_pb2.TwinID(id=twin_did)))
         return self.stub.DeleteTwin(req)
 
-    def list_twins(self, headers: typing.Optional[common_pb2.Headers] = None) -> twin_pb2.ListAllTwinsResponse:
+    def list_twins(self, 
+                   page:int =0,
+                   headers: typing.Optional[common_pb2.Headers] = None
+    ) -> twin_pb2.ListAllTwinsResponse:
         """Lists all local twins visible to the user making the request
 
         Args:
+            page: Used to request offsetted results, as responses contain only up to `PER_PAGE_LIMIT` results per request.
             headers: optional request headers
 
         Returns: Response object listing twins with their location and properties
         """
-        req = twin_pb2.ListAllTwinsRequest(headers=headers or create_headers())
+        
+        req = twin_pb2.ListAllTwinsRequest(
+            range=common_pb2.Range(
+                limit=common_pb2.Limit(value=PER_PAGE_LIMIT),
+                offset=common_pb2.Offset(value=PER_PAGE_LIMIT * page)
+            ),
+            headers=headers or create_headers())
         return self.stub.ListAllTwins(req)
 
     def update_twin(


### PR DESCRIPTION
Added range parameters to the list_twins to allow paging through results.

I have try to make the behavior consistent with search.dispatch_request functions which also uses the range parameter.
To make this more readable, I moved the PER_PAGE_LIMIT to the helpers class.
this is a non breaking change and existing uses would use the defaults (which equate to current behaviour)

There is also an update to the Makefile I needed to make this work ootb with ubuntu 22.04 (python command not in place by default).

The example will page through the local twin list until it has received all the twins (identified by not having a full page)

Example output is
```
(env) ➜  iotics-grpc-client-py git:(main) ✗ python3 examples/list_local_twins.py

Got replies from page #0 and found 100 twins on this page.
Got replies from page #1 and found 8 twins on this page.
found 108 twins in total.
```
Raised as issue https://ioticlabs.atlassian.net/browse/EI-3055

[contributed by @ipeteclarke]